### PR TITLE
Add layered scan mode and global rate limit, refactor fingerprint matching, bump to v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windfire"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Designed to be fast, lightweight, and highly concurrent, with full asynchronous 
 | Status Code Filtering    | Filter HTTP responses by status code (default: only 200)         |
 | Custom Path              | Supports specifying a custom path (default: `/`)                 |
 | Fingerprint Detection    | Identifies website CMS using an open-source fingerprint database |
+| Layered Scan Mode        | `alive` mode for liveness-only and `full` mode for fingerprinting |
+| Scan Rate Control        | `--rate` controls requests per second to protect targets         |
 | High Concurrency         | Supports high concurrency and asynchronous execution             |
 
 # Usage
@@ -38,6 +40,8 @@ Options:
   -p, --path <PATH>                Designated path scan [default: ]
   -x, --proxy <PROXY>              Supported Proxy socks5, http, and https
   -o, --output <OUTPUT>            Output to CSV or JSON file
+      --mode <MODE>                Scan mode: alive or full [default: full]
+      --rate <RATE>                Max requests per second (0 means unlimited) [default: 0]
   -h, --help                       Print help
   -V, --version                    Print version
 ```
@@ -53,6 +57,8 @@ Multiple values can be provided, separated by commas (e.g. 200,403)
 * -p, --path Specify a path to scan (default: empty)
 * -x, --proxy Proxy support (socks5, http, https), e.g. socks5://127.0.0.1:1080
 * -o, --output Export results to a CSV or JSON file, e.g. -o result.csv or -o result.json
+* --mode Scan mode: `alive` (liveness only) or `full` (liveness + fingerprint), default `full`
+* --rate Max requests per second. `0` means unlimited (default)
 * -h, --help Display help information
 * -V, --version Show version information
 
@@ -94,3 +100,10 @@ Output fields include:
 * Server
 * Response Size
 * Fingerprint Information
+
+## Release
+
+### v0.5.0
+- Added layered scan mode: `--mode alive|full`.
+- Added global request rate control: `--rate`.
+- Kept compatibility with existing output and filtering parameters.

--- a/src/cli/cli_options.rs
+++ b/src/cli/cli_options.rs
@@ -1,11 +1,17 @@
 // 主要做解析参数
 use url::Url;
 
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, Parser, ValueEnum};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ScanMode {
+    Alive,
+    Full,
+}
 
 #[derive(Parser, Debug)]
 #[command(
-    version = "0.0.4",
+    version = "0.5.0",
     about = "An efficient and fast url survival detection tool",
     long_about = "Efficient URL activity tester written in Rust. Fast, batch, and lightweight",
     group(
@@ -46,6 +52,14 @@ pub struct Args {
     /// Output can be a CSV or JSON file. Example: -o result.csv or -o result.json
     #[arg(short = 'o', long, value_parser = validate_output_format)]
     pub output: Option<String>,
+
+    /// Scan mode: alive (liveness only) or full (with fingerprint)
+    #[arg(long, value_enum, default_value_t = ScanMode::Full)]
+    pub mode: ScanMode,
+
+    /// Max requests per second (0 means unlimited)
+    #[arg(long, default_value_t = 0)]
+    pub rate: u32,
 }
 
 // 验证线程参数，不超过5000

--- a/src/fingerprint/loader.rs
+++ b/src/fingerprint/loader.rs
@@ -1,16 +1,8 @@
+use crate::fingerprint::matcher::FingerprintMatcher;
 use crate::fingerprint::model::Fingerprint;
 use std::error::Error;
 
-pub fn load_fingerprints_from_str(json: &str) -> Result<Vec<Fingerprint>, Box<dyn Error>> {
+pub fn load_fingerprints_from_str(json: &str) -> Result<FingerprintMatcher, Box<dyn Error>> {
     let configs: Vec<Fingerprint> = serde_json::from_str(json)?;
-
-    let mut result = Vec::with_capacity(configs.len());
-
-    for cfg in configs {
-        let fp =
-            Fingerprint::try_from(cfg).map_err(|e| format!("fingerprint parse error: {}", e))?;
-        result.push(fp);
-    }
-
-    Ok(result)
+    Ok(FingerprintMatcher::new(configs))
 }

--- a/src/fingerprint/matcher.rs
+++ b/src/fingerprint/matcher.rs
@@ -1,21 +1,73 @@
 use crate::fingerprint::model::{Fingerprint, MatchLocation, MatchMethod};
 use crate::http::response::ResponseInfo;
 
-impl Fingerprint {
-    // 指纹匹配
-    pub fn matches(&self, resp: &ResponseInfo) -> bool {
-        match self.method {
-            MatchMethod::Faviconhash => resp
-                .favicon_hash
-                .as_ref()
-                .is_some_and(|hash| self.keyword.iter().all(|k| k == hash)),
+#[derive(Debug, Clone)]
+struct CompiledFingerprint {
+    cms: String,
+    keywords: Vec<String>,
+}
 
-            MatchMethod::Keyword => {
-                let target = match self.location {
-                    MatchLocation::Header => &resp.headers,
-                    MatchLocation::Body => &resp.body,
-                };
-                self.keyword.iter().all(|k| target.contains(k))
+#[derive(Debug, Clone)]
+pub struct FingerprintMatcher {
+    favicon_rules: Vec<CompiledFingerprint>,
+    header_rules: Vec<CompiledFingerprint>,
+    body_rules: Vec<CompiledFingerprint>,
+}
+
+impl FingerprintMatcher {
+    pub fn new(fingerprints: Vec<Fingerprint>) -> Self {
+        let mut favicon_rules = Vec::new();
+        let mut header_rules = Vec::new();
+        let mut body_rules = Vec::new();
+
+        for fp in fingerprints {
+            let compiled = CompiledFingerprint {
+                cms: fp.cms,
+                keywords: fp.keyword,
+            };
+
+            match (fp.method, fp.location) {
+                (MatchMethod::Faviconhash, _) => favicon_rules.push(compiled),
+                (MatchMethod::Keyword, MatchLocation::Header) => header_rules.push(compiled),
+                (MatchMethod::Keyword, MatchLocation::Body) => body_rules.push(compiled),
+            }
+        }
+
+        Self {
+            favicon_rules,
+            header_rules,
+            body_rules,
+        }
+    }
+
+    pub fn match_response(&self, resp: &ResponseInfo) -> Vec<String> {
+        let mut matched = Vec::new();
+
+        if let Some(hash) = resp.favicon_hash.as_deref() {
+            for rule in &self.favicon_rules {
+                if rule.keywords.iter().all(|k| k == hash) {
+                    matched.push(rule.cms.clone());
+                }
+            }
+        }
+
+        self.match_keyword_rules(&self.header_rules, &resp.headers, &mut matched);
+        self.match_keyword_rules(&self.body_rules, &resp.body, &mut matched);
+
+        matched.sort();
+        matched.dedup();
+        matched
+    }
+
+    fn match_keyword_rules(
+        &self,
+        rules: &[CompiledFingerprint],
+        target: &str,
+        matched: &mut Vec<String>,
+    ) {
+        for rule in rules {
+            if rule.keywords.iter().all(|k| target.contains(k)) {
+                matched.push(rule.cms.clone());
             }
         }
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -6,12 +6,17 @@ pub async fn fetch(
     client: &Client,
     original_url: &str,
     status_code: &[u16],
+    with_favicon: bool,
 ) -> Result<ResponseInfo, Box<dyn std::error::Error + Send + Sync>> {
     let resp = client.get(original_url).send().await?;
 
     // 这块过滤状态码
     if status_code.contains(&resp.status().as_u16()) || status_code.is_empty() {
-        let favicon_hash = fetch_favicon_hash(client, original_url).await;
+        let favicon_hash = if with_favicon {
+            fetch_favicon_hash(client, original_url).await
+        } else {
+            None
+        };
         ResponseInfo::from_response(original_url, resp, favicon_hash).await
     } else {
         Err("filtered by status code".into())

--- a/src/input/url.rs
+++ b/src/input/url.rs
@@ -42,6 +42,10 @@ pub fn build_urls(args: &Args) -> Result<Vec<String>, Box<dyn Error>> {
     Ok(urls)
 }
 
+fn has_http_scheme(input: &str) -> bool {
+    input.starts_with("http://") || input.starts_with("https://")
+}
+
 // 读取文件
 fn read_urls_from_file(path: &str) -> Result<Vec<String>, Box<dyn Error>> {
     let file = File::open(path)?;
@@ -65,7 +69,7 @@ fn read_urls_from_file(path: &str) -> Result<Vec<String>, Box<dyn Error>> {
 
 // 解析http
 fn expand_line(line: &str) -> Vec<String> {
-    if line.starts_with("http://") || line.starts_with("https://") {
+    if has_http_scheme(line) {
         return vec![line.to_string()];
     }
 
@@ -85,7 +89,11 @@ fn expand_line(line: &str) -> Vec<String> {
 
 // 协议规则
 fn expand_ip_or_domain(input: &str) -> Vec<String> {
-    if let Some((_, port)) = input.split_once(':') {
+    if has_http_scheme(input) {
+        return vec![input.to_string()];
+    }
+
+    if let Some((_, port)) = input.rsplit_once(':') {
         match port {
             "443" => vec![format!("https://{}", input)],
             "80" => vec![format!("http://{}", input)],
@@ -97,7 +105,7 @@ fn expand_ip_or_domain(input: &str) -> Vec<String> {
 }
 
 fn normalize_urls(urls: Vec<String>, path: &str) -> Vec<String> {
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(urls.len());
 
     let path = path.trim_start_matches('/');
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let status_code = Arc::new(args.status_code);
 
-    let results = run(client, urls, fingerprints, args.thread, status_code).await;
+    let results = run(
+        client,
+        urls,
+        fingerprints,
+        args.thread,
+        status_code,
+        args.mode,
+        args.rate,
+    )
+    .await;
 
     output_results(results, args.output);
     Ok(())

--- a/src/runner/executor.rs
+++ b/src/runner/executor.rs
@@ -1,42 +1,54 @@
-use crate::fingerprint::model::Fingerprint;
+use crate::cli::cli_options::ScanMode;
+use crate::fingerprint::matcher::FingerprintMatcher;
 use crate::output::SaveInfo;
 use crate::scan::http_scan::scan_one;
 use futures::StreamExt;
 use reqwest::Client;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc;
+use tokio::time::{Duration, interval};
 
 pub async fn run(
     client: Client,
     urls: Vec<String>,
-    fingerprint: Arc<Vec<Fingerprint>>,
+    fingerprint: Arc<FingerprintMatcher>,
     threads: usize,
     status_code: Arc<Vec<u16>>,
+    mode: ScanMode,
+    rate: u32,
 ) -> Vec<SaveInfo> {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let threads = threads.max(1);
     let mut results = Vec::new();
-    let value = tx.clone();
+    let sender = tx.clone();
+    let ticker = (rate > 0).then(|| {
+        Arc::new(Mutex::new(interval(Duration::from_secs_f64(
+            1.0 / rate as f64,
+        ))))
+    });
     let scan_handle = tokio::spawn(async move {
         futures::stream::iter(urls)
             .map(|url| {
                 let client = client.clone();
                 let fps = Arc::clone(&fingerprint);
                 let status_code = Arc::clone(&status_code);
-                let tx = value.clone();
+                let tx = sender.clone();
+                let ticker = ticker.clone();
 
                 async move {
-                    match scan_one(&client, &url, &fps, &status_code).await {
-                        Ok(result) => {
-                            let _ = tx.send(result.clone());
-                            Some(result)
-                        }
-                        Err(_) => None,
+                    if let Some(ticker) = ticker {
+                        let mut guard = ticker.lock().await;
+                        guard.tick().await;
+                    }
+
+                    if let Ok(result) = scan_one(&client, &url, &fps, &status_code, mode).await {
+                        let _ = tx.send(result);
                     }
                 }
             })
             .buffer_unordered(threads)
-            .collect::<Vec<_>>()
+            .for_each(|_| async {})
             .await
     });
 

--- a/src/scan/http_scan.rs
+++ b/src/scan/http_scan.rs
@@ -1,4 +1,5 @@
-use crate::fingerprint::model::Fingerprint;
+use crate::cli::cli_options::ScanMode;
+use crate::fingerprint::matcher::FingerprintMatcher;
 use crate::http::request;
 use crate::output::SaveInfo;
 use reqwest::Client;
@@ -18,19 +19,16 @@ pub struct ScanResult {
 pub async fn scan_one(
     client: &Client,
     url: &str,
-    fingerprints: &[Fingerprint],
+    fingerprints: &FingerprintMatcher,
     status_code: &[u16],
+    mode: ScanMode,
 ) -> Result<SaveInfo, Box<dyn std::error::Error + Send + Sync>> {
-    let resp = request::fetch(client, url, status_code).await?;
-    let mut matched: Vec<String> = Vec::new();
-
-    for fp in fingerprints {
-        if fp.matches(&resp) {
-            matched.push(fp.cms.clone());
-        }
-    }
-    matched.sort();
-    matched.dedup();
+    let resp = request::fetch(client, url, status_code, mode == ScanMode::Full).await?;
+    let matched = if mode == ScanMode::Full {
+        fingerprints.match_response(&resp)
+    } else {
+        Vec::new()
+    };
 
     Ok(SaveInfo {
         url: resp.url,

--- a/zh-CN/README.md
+++ b/zh-CN/README.md
@@ -9,6 +9,8 @@
 | 状态码过滤|对 HTTP 响应的状态码进行过滤，默认只保留200 |
 | 指定路径 |支持指定路径进行测活，默认为根目录 |
 | 指纹识别 |采用开源指纹库识别网站CMS |
+| 探活模式分层 |支持 `alive`（只测活）和 `full`（测活+指纹）模式 |
+| 扫描速率控制 |支持 `--rate` 控制每秒请求数，避免压垮目标 |
 | 高并发 |支持高并发请求、支持异步 |
 
 # 用法
@@ -32,6 +34,8 @@ Options:
   -p, --path <PATH>                Designated path scan [default: ]
   -x, --proxy <PROXY>              Supported Proxy socks5, http, and https, Example: -x socks5://127.0.0.1:1080
   -o, --output <OUTPUT>            Output can be a CSV or JSON file. Example: -o result.csv or -o result.json
+      --mode <MODE>                Scan mode: alive or full [default: full]
+      --rate <RATE>                Max requests per second (0 means unlimited) [default: 0]
   -h, --help                       Print help (see more with '--help')
   -V, --version                    Print version
 ```
@@ -44,6 +48,8 @@ Options:
 * -p --path 指定扫描路径，默认为空，不指定，如 -p admin
 * -x --proxy 支持代理，目前支持socks5，http，https，如：-x socks5://127.0.0.1:1080
 * -o --output 支持将扫描结果导出为csv文件或者json文件，如：-o result.csv 或者 -o result.json
+* --mode 探活模式，`alive` 仅测活，`full` 测活+指纹（默认 `full`）
+* --rate 扫描速率限制，每秒请求数，`0` 表示不限速（默认）
 * -h --help 显示帮助信息
 * -V --version 显示版本信息
 
@@ -83,3 +89,10 @@ https://www.baidu.com [200] [百度一下，你就知道] [BWS/1.1] [414219] ["C
 * 服务器（server）
 * 响应页面大小（content_length）
 * 指纹信息
+
+## 版本发布
+
+### v0.5.0
+- 新增探活模式分层：`--mode alive|full`。
+- 新增全局扫描速率控制：`--rate`。
+- 兼容现有状态码过滤、代理与导出能力。


### PR DESCRIPTION
### Motivation
- Introduce a lightweight "alive" scan mode and keep a full fingerprinting mode to reduce unnecessary work when only liveness is required. 
- Provide an optional global request rate limit to avoid overloading targets during large scans. 
- Improve fingerprint handling by compiling fingerprints into a matcher for more efficient matching and clearer separation of concerns. 

### Description
- Bumped package version to `0.5.0` and updated CLI `version` string and documentation in `README.md` and `zh-CN/README.md` to document `--mode` and `--rate` flags.  
- Added `ScanMode` enum and new CLI options `--mode` (`alive`|`full`) and `--rate` (requests per second) in `src/cli/cli_options.rs`.  
- Refactored fingerprint loading and matching: `load_fingerprints_from_str` now returns a `FingerprintMatcher`, and a new `FingerprintMatcher` type compiles rules and exposes `match_response` in `src/fingerprint/*`.  
- Made favicon fetching optional based on mode by adding a `with_favicon` argument to `request::fetch` and only fetching when `mode == ScanMode::Full` in `src/scan/http_scan.rs`.  
- Updated executor to accept `mode` and `rate`, added a rate ticker using `tokio::time::interval` to pace requests when `--rate` > 0, and wired these through to `scan_one` in `src/runner/executor.rs`.  
- Adjusted URL input handling in `src/input/url.rs` to better detect existing HTTP schemes, use `rsplit_once` when parsing host:port, and optimize `normalize_urls` capacity.  
- Updated `src/main.rs` to pass `mode` and `rate` into the runner and to wrap loaded fingerprints in an `Arc<FingerprintMatcher>`.  

### Testing
- Built the project with `cargo build --release`, which completed successfully.  
- Ran `cargo test`, and all existing tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0413b0498483289ca692a89a94b3bc)